### PR TITLE
typo in ApiError "statck" corrected by "stack"

### DIFF
--- a/src/utils/ApiError.js
+++ b/src/utils/ApiError.js
@@ -3,7 +3,7 @@ class ApiError extends Error {
         statusCode,
         message= "Something went wrong",
         errors = [],
-        statck = ""
+        stack = ""
     ){
         super(message)
         this.statusCode = statusCode
@@ -12,8 +12,8 @@ class ApiError extends Error {
         this.success = false;
         this.errors = errors
 
-        if (statck) {
-            this.stack = statck
+        if (stack) {
+            this.stack = stack
         } else{
             Error.captureStackTrace(this, this.constructor)
         }


### PR DESCRIPTION
class ApiError extends Error {
    constructor(
        statusCode,
        message= "Something went wrong",
        errors = [],
        stack = ""
    ){
        super(message)
        this.statusCode = statusCode
        this.data = null
        this.message = message
        this.success = false;
        this.errors = errors
**### //change statck by stack**
        if (stack) {
            this.stack = stack
        } else{
            Error.captureStackTrace(this, this.constructor)
        }

    }
}

export {ApiError}