### PR TITLE
Update refreshToken value to null in logoutUser function

### DIFF
--- a/src/controllers/user.controller.js
+++ b/src/controllers/user.controller.js
@@ -162,7 +162,7 @@ const logoutUser = asyncHandler(async(req, res) => {
         req.user._id,
         {
             $set: {
-                refreshToken: undefined
+                refreshToken: null
             }
         },
         {

--- a/src/controllers/user.controller.js
+++ b/src/controllers/user.controller.js
@@ -158,6 +158,8 @@ const loginUser = asyncHandler(async (req, res) =>{
 })
 
 const logoutUser = asyncHandler(async(req, res) => {
+
+    // instead of undefined we should use the null
     await User.findByIdAndUpdate(
         req.user._id,
         {


### PR DESCRIPTION
fixes #27 

When we're working with MongoDB, setting a field to `undefined` means that the field will not be saved to the database at all. On the other hand, if you set a field to `null`, the field will be saved and its value will be `null`.

So, if you want to keep the `refreshToken` field in the document but clear its value, you should set it to `null`. If you set it to `undefined`, the `refreshToken` field will not be included in the document after you save it.