### PR TITLE
Update multer.middleware.js

### DIFF
--- a/src/middlewares/multer.middleware.js
+++ b/src/middlewares/multer.middleware.js
@@ -6,7 +6,7 @@ const storage = multer.diskStorage({
     },
     filename: function (req, file, cb) {
       
-      cb(null, file.originalname)
+      cb(null, "chai_" + Math.floor((Math.random() * 100) + 1) + file.originalname)
     }
   })
   


### PR DESCRIPTION
Bug found: when user upload same image for avatar and coverImage there was problem when unlinkSync those files after uploaded cloudinary avatar file is unlinked ( deleted ) but there is only one file ( because of same name ) that was removed and when we tried to unlink coverImage we got error.
Bug fixed : simply we can accept than same file but with some prefixes ( ex. user's file name => myimg.png   will be converted to  =>  chai_45myimg.png )