### PR TITLE
Update auth.middleware.js

### DIFF
--- a/src/middlewares/auth.middleware.js
+++ b/src/middlewares/auth.middleware.js
@@ -5,7 +5,7 @@ import { User } from "../models/user.model.js";
 
 export const verifyJWT = asyncHandler(async(req, _, next) => {
     try {
-        const token = req.cookies?.accessToken || req.header("Authorization")?.replace("Bearer ", "")
+        const token = req.cookies?.accessToken || req.headers["Authorization"]?.replace("Bearer ", "");
         
         // console.log(token);
         if (!token) {


### PR DESCRIPTION
A minor mistake in auth.moddleware.js
The correct property to access the headers object from the request object is `req.headers`, plural.