### PR TITLE
Fix avatar upload issue

### DIFF
--- a/src/utils/cloudinary.js
+++ b/src/utils/cloudinary.js
@@ -1,6 +1,4 @@
 import {v2 as cloudinary} from "cloudinary"
-import fs from "fs"
-
 
 cloudinary.config({ 
   cloud_name: process.env.CLOUDINARY_CLOUD_NAME, 
@@ -17,15 +15,11 @@ const uploadOnCloudinary = async (localFilePath) => {
         })
         // file has been uploaded successfull
         //console.log("file is uploaded on cloudinary ", response.url);
-        fs.unlinkSync(localFilePath)
         return response;
 
     } catch (error) {
-        fs.unlinkSync(localFilePath) // remove the locally saved temporary file as the upload operation got failed
         return null;
     }
 }
-
-
 
 export {uploadOnCloudinary}


### PR DESCRIPTION
Related to #115

Remove the deletion of local files after uploading to Cloudinary.

* Remove `fs.unlinkSync(localFilePath)` from `src/utils/cloudinary.js` to prevent deletion of local files after upload.
* Ensure the function `uploadOnCloudinary` returns the response from Cloudinary.

