### PR TITLE
Fix: Swap route handlers for subscribed channels and user subscribers

### DIFF
--- a/src/routes/subscription.routes.js
+++ b/src/routes/subscription.routes.js
@@ -11,9 +11,9 @@ router.use(verifyJWT); // Apply verifyJWT middleware to all routes in this file
 
 router
     .route("/c/:channelId")
-    .get(getSubscribedChannels)
+    .get(getUserChannelSubscribers)
     .post(toggleSubscription);
 
-router.route("/u/:subscriberId").get(getUserChannelSubscribers);
+router.route("/u/:subscriberId").get(getSubscribedChannels);
 
 export default router


### PR DESCRIPTION

This pull request includes changes to the `src/routes/subscription.routes.js` file to swap the handlers for two routes. The most important changes include:
* Modified the route `/c/:channelId` to use the `getUserChannelSubscribers` handler instead of `getSubscribedChannels`.
* Modified the route `/u/:subscriberId` to use the `getSubscribedChannels` handler instead of `getUserChannelSubscribers`.

This ensures the proper controller functions handle the expected requests.
As **getUserChannelSubscribers** has to return subscriber list of the channel and **getSubscribedChannels** has to return channel list to which user has subscribed.